### PR TITLE
 changing targetplatform from kepler to neon

### DIFF
--- a/org.eclipse.e4.tutorial.contacts.build.tycho/pom.xml
+++ b/org.eclipse.e4.tutorial.contacts.build.tycho/pom.xml
@@ -7,7 +7,7 @@
 	<packaging>pom</packaging>
 
 	<properties>
-		<tycho-version>0.20.0</tycho-version>
+		<tycho-version>0.26.0</tycho-version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 
@@ -49,11 +49,12 @@
 				<artifactId>target-platform-configuration</artifactId>
 				<version>${tycho-version}</version>
 				<configuration>
-
+					<!-- ### file artifactId.target is expected in org.eclipse.e4.tutorial.contacts.target	 -->
+					<!-- ### file org.eclipse.e4.tutorial.contacts.target/pom.xml is expected to contain that value too	 -->
 					<target>
 						<artifact>
 							<groupId>target</groupId>
-							<artifactId>kepler</artifactId>
+							<artifactId>neon</artifactId>
 							<version>1.0.0-SNAPSHOT</version>
 						</artifact>
 					</target>
@@ -80,11 +81,13 @@
 							<ws>gtk</ws>
 							<arch>x86_64</arch>
 						</environment>
-						<environment>
-							<os>macosx</os>
-							<ws>cocoa</ws>
-							<arch>x86</arch>
-						</environment>
+						<!-- ### 32-bit macosx-builds removed since mars -->
+						<!-- ### see: https://bugs.eclipse.org/bugs/show_bug.cgi?id=441691 -->
+<!-- 						<environment> -->
+<!-- 							<os>macosx</os> -->
+<!-- 							<ws>cocoa</ws> -->
+<!-- 							<arch>x86</arch> -->
+<!-- 						</environment> -->
 						<environment>
 							<os>macosx</os>
 							<ws>cocoa</ws>

--- a/org.eclipse.e4.tutorial.contacts.target/neon.target
+++ b/org.eclipse.e4.tutorial.contacts.target/neon.target
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<?pde version="3.8"?><target name="kepler" sequenceNumber="5">
+<?pde version="3.8"?><target name="neon" sequenceNumber="5">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="org.eclipse.sdk.ide" version="4.6.1.M20160907-1200"/>
+<unit id="org.eclipse.sdk.ide" version="0.0.0"/>
 <unit id="org.eclipse.equinox.executable.feature.group" version="0.0.0"/>
 <repository location="http://download.eclipse.org/releases/neon"/>
 </location>

--- a/org.eclipse.e4.tutorial.contacts.target/neon.target
+++ b/org.eclipse.e4.tutorial.contacts.target/neon.target
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?pde version="3.8"?><target name="kepler" sequenceNumber="5">
+<locations>
+<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.eclipse.sdk.ide" version="4.6.1.M20160907-1200"/>
+<unit id="org.eclipse.equinox.executable.feature.group" version="0.0.0"/>
+<repository location="http://download.eclipse.org/releases/neon"/>
+</location>
+</locations>
+</target>

--- a/org.eclipse.e4.tutorial.contacts.target/neon.target
+++ b/org.eclipse.e4.tutorial.contacts.target/neon.target
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<?pde version="3.8"?><target name="kepler" sequenceNumber="5">
+<?pde version="3.8"?><target name="neon" sequenceNumber="5">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.sdk.ide" version="4.6.1.M20160907-1200"/>

--- a/org.eclipse.e4.tutorial.contacts.target/pom.xml
+++ b/org.eclipse.e4.tutorial.contacts.target/pom.xml
@@ -9,7 +9,7 @@
 		<version>1.0.0-SNAPSHOT</version>
 	</parent>
 
-	<artifactId>kepler</artifactId>
+	<artifactId>neon</artifactId>
 	<packaging>eclipse-target-definition</packaging>
 	
   	<groupId>target</groupId>


### PR DESCRIPTION
Hi Kai,

i tried to get your fine example working in most current released versions of tycho/eclipse. I committed them into my fork and if you like them i'd be happy if you pull them in to your example repo. But beware of the following...

I am not completely sure about the filecontent of the neon.target - file.
- change of "target name" value: I am rather sure that eclipse-ide's "pde machinery" is interested  in the tag-values for "target name" / "sequenceNumber" / pde version ... but does tycho care about these? 
- zeroing (0.0.0) the dependency versions: Is this a wise thing to do? I locally experimented and successfully was able to complete a build. Zeroing would make upgrading to the +1 eclipse targetplatform much more easy as one does not need to find out a dependencies cryptic build/version number anymore

HTH
Daniel
